### PR TITLE
Initialize Python based AI Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node
+node_modules/
+dist/
+.env
+# Logs
+npm-debug.log*
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Welcome to **Love for Design**! This project is dedicated to exploring, sharing,
 The repository is organized as follows:
 
 ```
-src/       # Source code for tools, experiments, or utilities related to design
-docs/      # Documentation, guides, or articles about design techniques and processes
-assets/    # Images, icons, fonts, mockups, or design resources
-README.md  # You are here!
+ai-service/ # Python microservice providing AI-driven endpoints
+frontend/   # Web frontend built with Next.js
+README.md   # You are here!
 ```
 
 You are welcome to contribute to any part of the project or suggest new sections!

--- a/ai-service/.env.example
+++ b/ai-service/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=""
+PORT="3001"

--- a/ai-service/README.md
+++ b/ai-service/README.md
@@ -1,0 +1,27 @@
+# AI Service
+
+This folder contains a simple Python microservice built with Flask. It exposes an endpoint for generating text using the OpenAI API.
+
+## Setup
+
+1. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Copy `.env.example` to `.env` and set your `OPENAI_API_KEY`.
+
+## Usage
+
+Run the service locally with:
+
+```bash
+python app.py
+```
+
+The server listens on the port specified in `.env` (default `3001`).
+

--- a/ai-service/app.py
+++ b/ai-service/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, request, jsonify
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+app = Flask(__name__)
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    prompt = request.json.get('prompt', '')
+    try:
+        completion = client.chat.completions.create(
+            model='gpt-3.5-turbo',
+            messages=[{'role': 'user', 'content': prompt}]
+        )
+        result = completion.choices[0].message.content
+        return jsonify({'result': result})
+    except Exception as e:
+        app.logger.error(e)
+        return jsonify({'error': 'Failed to generate response'}), 500
+
+if __name__ == '__main__':
+    port = int(os.getenv('PORT', '3001'))
+    app.run(host='0.0.0.0', port=port)

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -1,0 +1,3 @@
+flask
+openai
+python-dotenv


### PR DESCRIPTION
## Summary
- initialize python based ai-service
- keep readme concise with just ai-service and frontend

## Testing
- `npm run check` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687536ad5fcc832e9bed57cd8513aac9